### PR TITLE
Update default hearthBeatUrl value to utilize the Internet health check...

### DIFF
--- a/projects/connection-service/README.MD
+++ b/projects/connection-service/README.MD
@@ -93,7 +93,7 @@ export interface ConnectionServiceOptions {
   enableHeartbeat?: boolean;
   /**
    * Url used for checking Internet connectivity, heartbeat system periodically makes "HEAD" requests to this URL to determine Internet
-   * connection status. Default value is "//server.test-cors.org".
+   * connection status. Default value is "'https://corsproxy.io?' + encodeURIComponent('https://internethealthtest.org')". (CORS restrictions are bypassed with this URL)
    */
   heartbeatUrl?: string;
   /**
@@ -109,7 +109,7 @@ export interface ConnectionServiceOptions {
    */
   heartbeatRetryInterval?: number;
   /**
-   * HTTP method used for requesting heartbeat Url. Default is 'head'.
+   * HTTP method used for requesting heartbeat Url. Default is 'get'.
    */
   requestMethod?: 'get' | 'post' | 'head' | 'options';
 

--- a/projects/connection-service/src/lib/connection-service.service.ts
+++ b/projects/connection-service/src/lib/connection-service.service.ts
@@ -64,10 +64,10 @@ export const ConnectionServiceOptionsToken: InjectionToken<ConnectionServiceOpti
 export class ConnectionService implements OnDestroy {
   private static DEFAULT_OPTIONS: ConnectionServiceOptions = {
     enableHeartbeat: true,
-    heartbeatUrl: '//server.test-cors.org/server?id=' + Date.now() + '&enable=true&status=200&credentials=false',
+    heartbeatUrl: 'https://corsproxy.io?' + encodeURIComponent('https://internethealthtest.org'),
     heartbeatInterval: 30000,
     heartbeatRetryInterval: 1000,
-    requestMethod: 'head',
+    requestMethod: 'get',
   };
 
   private stateChangeEventEmitter = new EventEmitter<ConnectionState>();
@@ -98,7 +98,7 @@ export class ConnectionService implements OnDestroy {
         heartbeatExecutor: () => this.http.request(
           this.serviceOptions.requestMethod,
           this.serviceOptions.heartbeatUrl,
-          {responseType: 'text'}
+          {responseType: 'text', withCredentials: false}
         ),
       });
 
@@ -110,6 +110,7 @@ export class ConnectionService implements OnDestroy {
 
     if (!_.isNil(this.httpSubscription)) {
       this.httpSubscription.unsubscribe();
+      this.httpSubscription = null;
     }
 
     if (this.serviceOptions.enableHeartbeat) {
@@ -146,6 +147,7 @@ export class ConnectionService implements OnDestroy {
 
     this.offlineSubscription = fromEvent(window, 'offline').subscribe(() => {
       this.currentState.hasNetworkConnection = false;
+      this.currentState.hasInternetAccess = false;
       this.checkInternetState();
       this.emitEvent();
     });


### PR DESCRIPTION
… with CORS bypass using "https://corsproxy.io" and "https://internethealthtest.org".

The default hearthBeatUrl value has been modified to combine both "https://corsproxy.io?" and "https://internethealthtest.org" addresses. By using "https://corsproxy.io" as a proxy, we can bypass CORS restrictions and effectively check the Internet status using "https://internethealthtest.org". This update ensures a smooth and accurate Internet health check process within the application.